### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-apk--method--count-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/1567)
 APK method count
 ============
-####[Deprecated - use official [APK analyzer](https://developer.android.com/studio/build/apk-analyzer.html)]
+#### [Deprecated - use official [APK analyzer](https://developer.android.com/studio/build/apk-analyzer.html)]
 
 *Output per-package method counts. Supports [multidex](https://developer.android.com/tools/building/multidex.html).*
 
@@ -13,7 +13,7 @@ Also you can now view per-class method counts for more detailed analysis. Inline
 
 It's written in TypeScript, If you want contribute - create a pull request or create an issue (If you have an idea or have you found an issue).
 
-###License
+### License
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
